### PR TITLE
Fix AGP compatibility with older dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,7 +51,7 @@ android {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.16.0")
+    implementation("androidx.core:core-ktx:1.15.0")
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.constraintlayout:constraintlayout:2.2.1")
@@ -59,7 +59,6 @@ dependencies {
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
     implementation("androidx.work:work-runtime-ktx:2.10.1")
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.9.1")
-    implementation("androidx.core:core-ktx:1.16.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.9.1")
     implementation("androidx.activity:activity-compose:1.10.1")
     implementation(platform("androidx.compose:compose-bom:2023.08.00"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+android.suppressUnsupportedCompileSdk=35


### PR DESCRIPTION
## Summary
- update `androidx.core:core-ktx` to 1.15.0 and remove the duplicate entry
- add `android.suppressUnsupportedCompileSdk` to gradle properties

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbee51b948323a98148fd0e01bcd6