### PR TITLE
Fix AppCompat theme

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Qotd_app" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.Qotd_app" parent="Theme.AppCompat.Light.NoActionBar" />
 </resources>


### PR DESCRIPTION
## Summary
- use an AppCompat parent theme

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e8258df0083238a6ae9ee7df8f5fa