### PR TITLE
Handle notification permission request

### DIFF
--- a/app/src/main/java/com/quvntvn/qotd_app/MainActivity.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/MainActivity.kt
@@ -1,17 +1,29 @@
 package com.quvntvn.qotd_app
 
+import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.widget.Button
 import android.widget.ProgressBar
 import android.widget.TextView
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 
 // 9. MainActivity.kt (Activité principale)
 class MainActivity : AppCompatActivity() {
     private val viewModel: QuoteViewModel by viewModels()
+    private val requestPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (!isGranted) {
+                Toast.makeText(this, R.string.notification_permission_denied, Toast.LENGTH_SHORT).show()
+            }
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -46,5 +58,28 @@ class MainActivity : AppCompatActivity() {
         }
 
         viewModel.loadDailyQuote()
+        requestNotificationPermissionIfNeeded()
+    }
+
+    private fun requestNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            when {
+                ContextCompat.checkSelfPermission(
+                    this,
+                    Manifest.permission.POST_NOTIFICATIONS
+                ) == PackageManager.PERMISSION_GRANTED -> {
+                    // Permission already granted
+                }
+
+                shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) -> {
+                    Toast.makeText(this, R.string.notification_permission_rationale, Toast.LENGTH_LONG).show()
+                    requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                }
+
+                else -> {
+                    requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                }
+            }
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">qotd_app</string>
+    <string name="notification_permission_rationale">Pour afficher les notifications quotidiennes de citations, l'application a besoin de la permission d'envoi de notifications.</string>
+    <string name="notification_permission_denied">Permission de notification refusée. Les citations quotidiennes ne seront pas affichées.</string>
 </resources>


### PR DESCRIPTION
## Summary
- request POST_NOTIFICATIONS permission at runtime
- add permission rationale and denial messages

## Testing
- `./gradlew test` *(fails: Starting a Gradle Daemon)*

------
https://chatgpt.com/codex/tasks/task_e_684f1bd9cf288323b312f8349c44c3b9