### PR TITLE
Fix Compose compile failure by updating Kotlin plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id("com.android.application") version "8.2.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.20" apply false
 }


### PR DESCRIPTION
## Summary
- update Kotlin plugin to 1.9.20 to match Compose compiler requirements

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f30799b1c8323af099c1fa4889085