### PR TITLE
Fix null date crash in MainActivity

### DIFF
--- a/app/src/main/java/com/quvntvn/qotd_app/MainActivity.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/MainActivity.kt
@@ -49,7 +49,12 @@ class MainActivity : AppCompatActivity() {
             quote?.let {
                 tvQuote.text = it.citation
                 tvAuthor.text = it.auteur
-                tvYear.text = it.dateCreation.substring(0, 4)
+                val date = it.dateCreation
+                tvYear.text = if (date != null && date.length >= 4) {
+                    date.substring(0, 4)
+                } else {
+                    "N/A"
+                }
             }
         }
 

--- a/app/src/main/java/com/quvntvn/qotd_app/NotificationHelper.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/NotificationHelper.kt
@@ -34,11 +34,15 @@ class NotificationHelper(private val context: Context) {
     }
 
     fun showNotification(quote: Quote) {
-        val year = try {
-            SimpleDateFormat("yyyy", Locale.getDefault()).format(
-                SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).parse(quote.dateCreation)!!
-            )
-        } catch (e: Exception) { "N/A" }
+        val year = quote.dateCreation?.let {
+            try {
+                SimpleDateFormat("yyyy", Locale.getDefault()).format(
+                    SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).parse(it)!!
+                )
+            } catch (e: Exception) {
+                "N/A"
+            }
+        } ?: "N/A"
 
         val notification = NotificationCompat.Builder(context, channelId)
             .setSmallIcon(android.R.drawable.ic_dialog_info)

--- a/app/src/main/java/com/quvntvn/qotd_app/Quote.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/Quote.kt
@@ -6,5 +6,5 @@ import com.google.gson.annotations.SerializedName
 data class Quote(
     val citation: String,
     val auteur: String,
-    @SerializedName("date_creation") val dateCreation: String
+    @SerializedName("date_creation") val dateCreation: String?
 )


### PR DESCRIPTION
## Summary
- allow `dateCreation` to be nullable
- guard against null date when updating UI
- handle missing date in notifications

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f341e29288323814b34756ed6ac88