### PR TITLE
Set Paris timezone for daily quote and use 24h picker

### DIFF
--- a/app/src/main/java/com/quvntvn/qotd_app/QuoteWorker.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/QuoteWorker.kt
@@ -9,6 +9,7 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import java.util.Calendar
+import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 
 // 6. QuoteWorker.kt (Tâche de fond)
@@ -56,8 +57,9 @@ class QuoteWorker(
         }
 
         private fun calculateDelay(targetHour: Int): Long {
-            val current = Calendar.getInstance()
-            val dueDate = Calendar.getInstance().apply {
+            val tz = TimeZone.getTimeZone("Europe/Paris")
+            val current = Calendar.getInstance(tz)
+            val dueDate = Calendar.getInstance(tz).apply {
                 set(Calendar.HOUR_OF_DAY, targetHour)
                 set(Calendar.MINUTE, 0)
                 set(Calendar.SECOND, 0)

--- a/app/src/main/java/com/quvntvn/qotd_app/SettingsActivity.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/SettingsActivity.kt
@@ -17,6 +17,7 @@ class SettingsActivity : AppCompatActivity() {
         val (enabled, hour) = SharedPrefManager.getNotificationSettings(this)
         val switch = findViewById<SwitchCompat>(R.id.switch_notifications)
         val timePicker = findViewById<TimePicker>(R.id.timePicker)
+        timePicker.setIs24HourView(true)
 
         switch.isChecked = enabled
         timePicker.hour = hour

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -33,7 +33,8 @@
         android:id="@+id/timePicker"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:timePickerMode="spinner"/>
+        android:timePickerMode="spinner"
+        android:is24HourView="true"/>
 
     <Button
         android:id="@+id/btn_save"


### PR DESCRIPTION
## Summary
- force Settings time picker to use 24-hour display
- show 24h time in settings layout
- schedule daily quote using `Europe/Paris` timezone

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d30f49508323a0f02a739f5b35e4