### PR TITLE
Fix TimePicker attribute

### DIFF
--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -35,7 +35,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:timePickerMode="spinner"
-        app:is24Hour="true"/>
+        android:is24HourView="true"/>
 
     <Button
         android:id="@+id/btn_save"


### PR DESCRIPTION
## Summary
- correct TimePicker attribute `is24HourView` in settings screen

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68527e76f6148323bc9ed19cd407712a