### PR TITLE
Fix resource linking error

### DIFF
--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -34,8 +34,7 @@
         android:id="@+id/timePicker"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:timePickerMode="spinner"
-        android:is24HourView="true"/>
+        android:timePickerMode="spinner"/>
 
     <Button
         android:id="@+id/btn_save"


### PR DESCRIPTION
## Summary
- remove invalid `is24HourView` attribute from `activity_settings.xml`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68528c41b81c83239af915aebeff4ca0