### PR TITLE
Fix ConstraintLayout class in settings layout

### DIFF
--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,5 +1,5 @@
 <!-- 12. res/layout/activity_settings.xml -->
-<ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
@@ -43,4 +43,4 @@
         android:layout_marginTop="24dp"
         android:layout_marginBottom="50dp"
         android:text="Enregistrer" />
-</ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- fix crash from missing ConstraintLayout class by using the AndroidX fully qualified name

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f720e7548323859e45b7cd642bb5