### PR TITLE
Add back button to settings screen

### DIFF
--- a/app/src/main/java/com/quvntvn/qotd_app/SettingsActivity.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/SettingsActivity.kt
@@ -32,6 +32,10 @@ class SettingsActivity : AppCompatActivity() {
             timePicker.isEnabled = isChecked
         }
 
+        findViewById<Button>(R.id.btn_back).setOnClickListener {
+            finish()
+        }
+
         findViewById<Button>(R.id.btn_save).setOnClickListener {
             val newHour = timePicker.hour
             val newMinute = timePicker.minute // <--- RÉCUPÉRER LES MINUTES

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -59,6 +59,17 @@
         app:layout_constraintEnd_toEndOf="parent" />
 
     <Button
+        android:id="@+id/btn_back"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="Retour"
+        android:textStyle="bold"
+        android:layout_marginBottom="8dp"
+        app:layout_constraintBottom_toTopOf="@id/btn_save"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <Button
         android:id="@+id/btn_save"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
## Summary
- add a `Retour` button to the settings screen layout
- wire the button to close `SettingsActivity`

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854496788708323a2e40eed87765e45