### PR TITLE
Add language switch

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,8 @@ dependencies {
     implementation("androidx.work:work-runtime-ktx:2.10.1")
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.9.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.9.1")
+    implementation("com.google.mlkit:translate:17.0.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.1")
     implementation("androidx.activity:activity-compose:1.10.1")
     implementation(platform("androidx.compose:compose-bom:2025.06.00"))
     implementation("androidx.compose.ui:ui")

--- a/app/src/main/java/com/quvntvn/qotd_app/MainActivity.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/MainActivity.kt
@@ -17,6 +17,8 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels // Correction de l'import pour viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
 
 // 9. MainActivity.kt (Activité principale)
 class MainActivity : AppCompatActivity() {
@@ -65,15 +67,20 @@ class MainActivity : AppCompatActivity() {
             startActivity(Intent(this@MainActivity, SettingsActivity::class.java))
         }
 
+        val translator = TranslationManager(this)
         viewModel.quote.observe(this) { quote ->
-            quote?.let {
-                tvQuote.text = "\"${it.citation}\""
-                tvAuthor.text = it.auteur
-                val date = it.dateCreation
-                tvYear.text = if (date != null && date.length >= 4) {
-                    date.substring(0, 4)
-                } else {
-                    "N/A"
+            quote?.let { q ->
+                lifecycleScope.launch {
+                    val lang = SharedPrefManager.getLanguage(this@MainActivity)
+                    val text = translator.translate(q.citation, lang)
+                    tvQuote.text = "\"$text\""
+                    tvAuthor.text = q.auteur
+                    val date = q.dateCreation
+                    tvYear.text = if (date != null && date.length >= 4) {
+                        date.substring(0, 4)
+                    } else {
+                        "N/A"
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/quvntvn/qotd_app/SettingsActivity.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/SettingsActivity.kt
@@ -3,6 +3,8 @@ package com.quvntvn.qotd_app
 import android.os.Bundle
 import android.widget.Button
 import android.widget.TimePicker
+import android.widget.Spinner
+import android.widget.ArrayAdapter
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SwitchCompat
@@ -22,6 +24,17 @@ class SettingsActivity : AppCompatActivity() {
         val switchNotifications = findViewById<SwitchCompat>(R.id.switch_notifications)
         val timePicker = findViewById<TimePicker>(R.id.timePicker)
         timePicker.setIs24HourView(true)
+        val spinnerLanguage = findViewById<Spinner>(R.id.spinner_language)
+        val adapter = ArrayAdapter.createFromResource(
+            this,
+            R.array.languages,
+            android.R.layout.simple_spinner_item
+        )
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        spinnerLanguage.adapter = adapter
+
+        val savedLanguage = SharedPrefManager.getLanguage(this)
+        spinnerLanguage.setSelection(if (savedLanguage == "en") 1 else 0)
 
         switchNotifications.isChecked = enabled
         timePicker.hour = savedHour
@@ -40,6 +53,8 @@ class SettingsActivity : AppCompatActivity() {
             val newHour = timePicker.hour
             val newMinute = timePicker.minute // <--- RÉCUPÉRER LES MINUTES
             val notificationsAreEnabled = switchNotifications.isChecked
+            val selectedLanguage = if (spinnerLanguage.selectedItemPosition == 1) "en" else "fr"
+            SharedPrefManager.saveLanguage(this, selectedLanguage)
 
             // Adapter SharedPrefManager pour sauvegarder aussi les minutes
             SharedPrefManager.saveSettings(this, notificationsAreEnabled, newHour, newMinute) // <--- PASSER LES MINUTES ICI

--- a/app/src/main/java/com/quvntvn/qotd_app/SharedPrefManager.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/SharedPrefManager.kt
@@ -8,6 +8,7 @@ object SharedPrefManager {
     private const val NOTIFICATION_ENABLED = "notif_enabled"
     private const val NOTIFICATION_HOUR = "notif_hour"
     private const val NOTIFICATION_MINUTE = "notif_minute" // Nouvelle clé
+    private const val LANGUAGE = "language"
 
     // Sauvegarde les paramètres de notification
     fun saveSettings(context: Context, enabled: Boolean, hour: Int, minute: Int) {
@@ -31,6 +32,19 @@ object SharedPrefManager {
             prefs.getInt(NOTIFICATION_HOUR, 10),       // Valeur par défaut : 10h
             prefs.getInt(NOTIFICATION_MINUTE, 0)        // Valeur par défaut : 00 minutes
         )
+    }
+
+    fun saveLanguage(context: Context, language: String) {
+        context
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(LANGUAGE, language)
+            .apply()
+    }
+
+    fun getLanguage(context: Context): String {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        return prefs.getString(LANGUAGE, "fr") ?: "fr"
     }
 }
 

--- a/app/src/main/java/com/quvntvn/qotd_app/TranslationManager.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/TranslationManager.kt
@@ -1,0 +1,28 @@
+package com.quvntvn.qotd_app
+
+import android.content.Context
+import com.google.mlkit.nl.translate.TranslateLanguage
+import com.google.mlkit.nl.translate.Translator
+import com.google.mlkit.nl.translate.TranslatorOptions
+import com.google.mlkit.nl.translate.Translation
+import kotlinx.coroutines.tasks.await
+
+class TranslationManager(private val context: Context) {
+    private val frToEnTranslator: Translator by lazy {
+        val options = TranslatorOptions.Builder()
+            .setSourceLanguage(TranslateLanguage.FRENCH)
+            .setTargetLanguage(TranslateLanguage.ENGLISH)
+            .build()
+        Translation.getClient(options)
+    }
+
+    suspend fun translate(text: String, target: String): String {
+        if (target == "fr") return text
+        val translator = when (target) {
+            "en" -> frToEnTranslator
+            else -> return text
+        }
+        translator.downloadModelIfNeeded().await()
+        return translator.translate(text).await()
+    }
+}

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -61,6 +61,29 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
+    <TextView
+        android:id="@+id/tv_language_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Langue"
+        android:textSize="20dp"
+        android:fontFamily="@font/ptsans"
+        android:textColor="@color/black"
+        android:layout_marginTop="24dp"
+        app:layout_constraintTop_toBottomOf="@id/timePicker"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <Spinner
+        android:id="@+id/spinner_language"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:entries="@array/languages"
+        app:layout_constraintTop_toBottomOf="@id/tv_language_label"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <!-- Bouton Enregistrer maintenant en bas -->
     <Button
         android:id="@+id/btn_save"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,8 @@
     <string name="notification_channel_description">Notifications pour les citations quotidiennes</string>
     <string name="notification_permission_rationale">Pour afficher les citations quotidiennes, l\'application demande la permission de notifications.</string>
     <string name="notification_permission_denied">Permission de notification refusée. Les citations quotidiennes ne seront pas affichées.</string>
+    <string-array name="languages">
+        <item>Français</item>
+        <item>English</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
## Summary
- add string array with languages
- add spinner to settings to select language
- persist language choice via `SharedPrefManager`
- add `TranslationManager` using ML Kit
- translate quotes in `MainActivity`
- include ML Kit dependencies

## Testing
- `./gradlew test -q` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a6f7ac0348323a6c8432c5c17c636