### PR TITLE
Fix language change without app restart

### DIFF
--- a/app/src/main/java/com/quvntvn/qotd_app/MainActivity.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/MainActivity.kt
@@ -34,6 +34,15 @@ class MainActivity : AppCompatActivity() {
                 Toast.makeText(this, R.string.notification_permission_denied, Toast.LENGTH_SHORT).show()
             }
         }
+    private val settingsLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == RESULT_OK) {
+                val changed = result.data?.getBooleanExtra("languageChanged", false) ?: false
+                if (changed) {
+                    recreate()
+                }
+            }
+        }
 
     @SuppressLint("SetTextI18n")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -69,7 +78,7 @@ class MainActivity : AppCompatActivity() {
             btnDaily.visibility = View.GONE
         }
         btnSettings.setOnClickListener {
-            startActivity(Intent(this@MainActivity, SettingsActivity::class.java))
+            settingsLauncher.launch(Intent(this@MainActivity, SettingsActivity::class.java))
         }
 
         val translator = TranslationManager(this)


### PR DESCRIPTION
## Summary
- launch `SettingsActivity` for a result
- set result on save when language changes
- recreate `MainActivity` when the language changes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b94f155448323a6577151520c639c