### PR TITLE
Fix glass card blur and rounded corners

### DIFF
--- a/app/src/main/java/com/quvntvn/qotd_app/MainActivity.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/MainActivity.kt
@@ -5,8 +5,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.graphics.RenderEffect
-import android.graphics.Shader
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
@@ -66,14 +64,7 @@ class MainActivity : AppCompatActivity() {
         val glassBackground = findViewById<View>(R.id.glass_background_view)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            val blurRadiusX = 60f
-            val blurRadiusY = 60f
-            val blur = RenderEffect.createBlurEffect(
-                blurRadiusX,
-                blurRadiusY,
-                Shader.TileMode.MIRROR
-            )
-            glassBackground.setRenderEffect(blur)
+            glassBackground.setBackgroundBlurRadius(60)
         }
 
         val (enabled, hour, minute) = SharedPrefManager.getNotificationSettings(this)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -60,6 +60,7 @@
             android:layout_height="0dp"
             android:background="@drawable/glass_background"
             android:elevation="8dp"
+            android:clipToOutline="true"
             app:layout_constraintTop_toTopOf="@id/tvQuote"
             app:layout_constraintBottom_toBottomOf="@id/tvYear"
             app:layout_constraintStart_toStartOf="@id/tvQuote"


### PR DESCRIPTION
## Summary
- apply background blur using setBackgroundBlurRadius
- clip the glass view outline so rounded corners show

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d54dd65d88323bf9df7d5914cbae9