### PR TITLE
Fix Settings TimePicker and language spinner

### DIFF
--- a/app/src/main/java/com/quvntvn/qotd_app/SettingsActivity.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/SettingsActivity.kt
@@ -76,15 +76,11 @@ class SettingsActivity : AppCompatActivity() {
 
         // Sélectionner la langue sauvegardée dans le Spinner
         val languageIndex = when (savedLanguage.lowercase(Locale.ROOT)) {
-            "en" -> languagesArray.indexOfFirst { it.equals("English", ignoreCase = true) }
-            "fr" -> languagesArray.indexOfFirst { it.equals("Français", ignoreCase = true) }
-            else -> 0 // Par défaut à la première langue si non trouvée ou langue inconnue
+            "en" -> 1
+            "fr" -> 0
+            else -> 0
         }
-        if (languageIndex != -1) {
-            languageSpinner.setSelection(languageIndex)
-        } else {
-            languageSpinner.setSelection(0) // Sécurité, sélectionne le premier élément
-        }
+        languageSpinner.setSelection(languageIndex)
 
         // Bouton Retour
         findViewById<Button>(R.id.btn_back).setOnClickListener {

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -132,8 +132,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:timePickerMode="spinner"
-                android:theme="@style/SettingsTimePicker"
-            android:layout_marginTop="8dp"/>
+                style="@style/SettingsTimePicker"
+                android:layout_marginTop="8dp"/>
         </LinearLayout>
     </eightbitlab.com.blurview.BlurView>
 
@@ -175,7 +175,7 @@
                 android:entries="@array/languages"
                 android:popupBackground="@color/glass_tint"
                 android:layout_marginTop="8dp"
-                android:theme="@style/SettingsSpinner" />
+                style="@style/SettingsSpinner" />
 
         </LinearLayout>
     </eightbitlab.com.blurview.BlurView>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -18,7 +18,7 @@
     <style name="SettingsTimePicker" parent="android:Widget.Material.Light.TimePicker">
         <!-- Pour le mode spinner -->
         <item name="android:textColorPrimary">@color/white</item> <!-- Couleur des chiffres et AM/PM non sélectionnés -->
-        <item name="android:textColorSecondary">#B3FFFFFF</item> <!-- Couleur des séparateurs ":" -->
+        <item name="android:textColorSecondary">@color/white</item> <!-- Couleur des séparateurs ":" -->
         <item name="android:numbersTextColor">@color/white</item> <!-- Couleur principale des chiffres -->
         <item name="android:numbersSelectorColor">@color/colorAccent</item> <!-- Couleur du sélecteur de chiffres (la surbrillance) -->
         <item name="android:numbersBackgroundColor">#33FFFFFF</item> <!-- Couleur de fond derrière les chiffres (légèrement visible) -->


### PR DESCRIPTION
## Summary
- style TimePicker with colon in white
- use style attribute for TimePicker and Spinner
- fix language spinner initialization

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e961bc9088323baf95ad609348d44