### PR TITLE
Fix TimePicker color in settings

### DIFF
--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -132,7 +132,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:timePickerMode="spinner"
-                style="@style/SettingsTimePicker"
+                android:theme="@style/SettingsTimePicker"
                 android:layout_marginTop="8dp"/>
         </LinearLayout>
     </eightbitlab.com.blurview.BlurView>


### PR DESCRIPTION
## Summary
- ensure the TimePicker uses white text by applying the custom theme in portrait layout

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e9959517c8323bbba29a122ffec03