### PR TITLE
Handle fetch errors with default quote

### DIFF
--- a/app/src/main/java/com/quvntvn/qotd_app/MainActivity.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/MainActivity.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.launch
 import android.graphics.Color
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import com.quvntvn.qotd_app.Quote
 
 class MainActivity : AppCompatActivity() {
 
@@ -142,17 +143,27 @@ class MainActivity : AppCompatActivity() {
         val translator = TranslationManager(this)
 
         viewModel.quote.observe(this) { q ->
-            q ?: return@observe
             lifecycleScope.launch {
                 val lang = SharedPrefManager.getLanguage(this@MainActivity)
-                tvQuote.text  = "« ${translator.translate(q.citation, lang)} »"
-                tvAuthor.text = q.auteur
-                tvYear.text   = q.dateCreation?.take(4) ?: getString(R.string.not_available_abbr)
+                val quoteToShow = q ?: run {
+                    Toast.makeText(this@MainActivity, R.string.error_fetch_quote, Toast.LENGTH_SHORT).show()
+                    Quote(
+                        getString(R.string.default_quote_text),
+                        getString(R.string.default_quote_author),
+                        getString(R.string.default_quote_year)
+                    )
+                }
+
+                tvQuote.text  = "« ${translator.translate(quoteToShow.citation, lang)} »"
+                tvAuthor.text = quoteToShow.auteur
+                tvYear.text   = quoteToShow.dateCreation?.take(4) ?: getString(R.string.not_available_abbr)
             }
         }
 
+        val divider = findViewById<View>(R.id.quote_author_divider)
         viewModel.isLoading.observe(this) { loading ->
             progressBar.visibility = if (loading) View.VISIBLE else View.GONE
+            divider.visibility = if (loading) View.INVISIBLE else View.VISIBLE
         }
 
         // Charge la citation du jour au démarrage de l'activité

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -109,6 +109,17 @@
                     android:gravity="center"
                     tools:text="La plus grande gloire n’est pas de ne jamais tomber…" />
 
+                <View
+                    android:id="@+id/quote_author_divider"
+                    android:layout_width="100dp"
+                    android:layout_height="1dp"
+                    android:layout_gravity="center"
+                    android:background="#99FFFFFF"
+                    android:layout_marginTop="20dp"
+                    android:layout_marginBottom="10dp"
+                    android:layout_marginStart="32dp"
+                    android:layout_marginEnd="32dp" />
+
                 <TextView
                     android:id="@+id/tvAuthor"
                     android:layout_width="match_parent"

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -20,4 +20,10 @@
     <string name="notifications_scheduled">Notifications scheduled for %1$02dh%2$02d</string>
     <string name="notifications_disabled">Notifications disabled</string>
     <string name="settings_title">Settings</string>
+
+    <!-- Default quote shown when API fails -->
+    <string name="default_quote_text">Courage is not the absence of fear, but the ability to overcome what frightens.</string>
+    <string name="default_quote_author">Nelson Mandela</string>
+    <string name="default_quote_year">1996</string>
+    <string name="error_fetch_quote">Unable to retrieve quote. Check your connection.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,4 +22,10 @@
     <string name="notifications_scheduled">Notifications programmées pour %1$02dh%2$02d</string>
     <string name="notifications_disabled">Notifications désactivées</string>
     <string name="settings_title">Réglages</string>
+
+    <!-- Citation par défaut affichée en cas d'erreur -->
+    <string name="default_quote_text">Le courage n'est pas l'absence de peur, mais la capacité de vaincre ce qui fait peur.</string>
+    <string name="default_quote_author">Nelson Mandela</string>
+    <string name="default_quote_year">1996</string>
+    <string name="error_fetch_quote">Impossible de récupérer la citation. Vérifiez votre connexion.</string>
 </resources>


### PR DESCRIPTION
## Summary
- display a divider between quote and author
- hide divider while loading
- show a default quote and toast if fetch fails
- add strings for the default quote in French and English

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fad2296d08323bd5e2bb35ea0ef22