### PR TITLE
Add error toast with default quote

### DIFF
--- a/app/src/main/java/com/quvntvn/qotd_app/MainActivity.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/MainActivity.kt
@@ -81,6 +81,7 @@ class MainActivity : AppCompatActivity() {
         val tvAuthor        = findViewById<TextView>(R.id.tvAuthor)
         val tvYear          = findViewById<TextView>(R.id.tvYear)
         val progressBar     = findViewById<ProgressBar>(R.id.progressBar)
+        val divider         = findViewById<View>(R.id.quote_author_divider)
         // val tvAppName       = findViewById<TextView>(R.id.tvAppName) // Le TextView lui-même n'est plus directement manipulé pour le flou
 
         // BlurViews
@@ -153,6 +154,12 @@ class MainActivity : AppCompatActivity() {
 
         viewModel.isLoading.observe(this) { loading ->
             progressBar.visibility = if (loading) View.VISIBLE else View.GONE
+            divider.visibility = if (loading) View.GONE else View.VISIBLE
+        }
+
+        viewModel.errorMessage.observe(this) { msgRes ->
+            msgRes ?: return@observe
+            Toast.makeText(this, msgRes, Toast.LENGTH_SHORT).show()
         }
 
         // Charge la citation du jour au démarrage de l'activité

--- a/app/src/main/java/com/quvntvn/qotd_app/QuoteViewModel.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/QuoteViewModel.kt
@@ -10,11 +10,25 @@ class QuoteViewModel : ViewModel() {
     private val repository = QuoteRepository()
     val quote = MutableLiveData<Quote?>()
     val isLoading = MutableLiveData(false)
+    val errorMessage = MutableLiveData<Int?>()
+
+    private val defaultQuote = Quote(
+        "Le courage n'est pas l'absence de peur, mais la capacité de vaincre ce qui fait peur.",
+        "Nelson Mandela",
+        "1996"
+    )
 
     fun loadDailyQuote() {
         viewModelScope.launch {
             isLoading.value = true
-            quote.value = repository.getDailyQuote()
+            val result = repository.getDailyQuote()
+            if (result == null) {
+                errorMessage.value = R.string.quote_error
+                quote.value = defaultQuote
+            } else {
+                quote.value = result
+                errorMessage.value = null
+            }
             isLoading.value = false
         }
     }
@@ -22,7 +36,14 @@ class QuoteViewModel : ViewModel() {
     fun loadRandomQuote() {
         viewModelScope.launch {
             isLoading.value = true
-            quote.value = repository.getRandomQuote()
+            val result = repository.getRandomQuote()
+            if (result == null) {
+                errorMessage.value = R.string.quote_error
+                quote.value = defaultQuote
+            } else {
+                quote.value = result
+                errorMessage.value = null
+            }
             isLoading.value = false
         }
     }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -20,4 +20,5 @@
     <string name="notifications_scheduled">Notifications scheduled for %1$02dh%2$02d</string>
     <string name="notifications_disabled">Notifications disabled</string>
     <string name="settings_title">Settings</string>
+    <string name="quote_error">Unable to retrieve quote, showing a default one.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,4 +22,5 @@
     <string name="notifications_scheduled">Notifications programmées pour %1$02dh%2$02d</string>
     <string name="notifications_disabled">Notifications désactivées</string>
     <string name="settings_title">Réglages</string>
+    <string name="quote_error">Impossible de récupérer la citation, affichage d\u2019une citation par défaut.</string>
 </resources>


### PR DESCRIPTION
## Summary
- provide default quote when retrieval fails
- show toast on quote error
- hide divider while loading
- add translatable string for quote error message

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc2dec5e4832387f21fef99494024