### PR TITLE
Add simple Quote widget

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,14 @@
             </intent-filter>
         </activity>
         <!-- Activity to configure daily quote notifications -->
+        <receiver android:name=".QuoteWidgetReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+            <meta-data android:name="android.appwidget.provider" android:resource="@xml/quote_widget_info"/>
+        </receiver>
+
         <activity
             android:name=".SettingsActivity"
             android:exported="false"

--- a/app/src/main/java/com/quvntvn/qotd_app/QuoteWidget.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/QuoteWidget.kt
@@ -1,0 +1,104 @@
+package com.quvntvn.qotd_app
+
+import android.content.Context
+import androidx.glance.GlanceModifier
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.state.updateAppWidgetState
+import androidx.glance.appwidget.state.PreferencesGlanceStateDefinition
+import androidx.glance.text.TextAlign
+import androidx.glance.unit.ColorProvider
+import androidx.glance.text.FontWeight
+import androidx.glance.text.TextStyle
+import androidx.glance.layout.Column
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.padding
+import androidx.glance.layout.Alignment
+import androidx.glance.text.Text
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.height
+import androidx.glance.unit.dp
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Simple app widget showing the quote of the day.
+ */
+class QuoteWidget : GlanceAppWidget() {
+    override val stateDefinition = PreferencesGlanceStateDefinition
+
+    override suspend fun onUpdate(context: Context, ids: IntArray) {
+        super.onUpdate(context, ids)
+        updateQuote(context, ids)
+    }
+
+    override suspend fun Content() {
+        val prefs = currentState<Preferences>()
+        val quote = prefs[KEY_QUOTE] ?: ""
+        val author = prefs[KEY_AUTHOR] ?: ""
+        val year = prefs[KEY_YEAR] ?: ""
+
+        Column(
+            modifier = GlanceModifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "\u00AB $quote \u00BB",
+                style = TextStyle(
+                    textAlign = TextAlign.Center,
+                    fontWeight = FontWeight.Medium,
+                    color = ColorProvider(android.graphics.Color.WHITE)
+                )
+            )
+            Spacer(modifier = GlanceModifier.height(8.dp))
+            Text(
+                text = author,
+                style = TextStyle(
+                    textAlign = TextAlign.Center,
+                    color = ColorProvider(android.graphics.Color.WHITE)
+                )
+            )
+            if (year.isNotEmpty()) {
+                Text(
+                    text = year,
+                    style = TextStyle(
+                        textAlign = TextAlign.Center,
+                        color = ColorProvider(android.graphics.Color.WHITE)
+                    )
+                )
+            }
+        }
+    }
+
+    private suspend fun updateQuote(context: Context, ids: IntArray) {
+        val repo = QuoteRepository()
+        val quote = withContext(Dispatchers.IO) { repo.getDailyQuote() }
+        ids.forEach { id ->
+            updateAppWidgetState(context, PreferencesGlanceStateDefinition, id) { prefs ->
+                val mutable = prefs.toMutablePreferences()
+                if (quote != null) {
+                    mutable[KEY_QUOTE] = quote.citation
+                    mutable[KEY_AUTHOR] = quote.auteur
+                    mutable[KEY_YEAR] = quote.dateCreation?.take(4) ?: ""
+                }
+                mutable
+            }
+        }
+        // Refresh widget UI
+        updateAll(context)
+    }
+
+    companion object {
+        private val KEY_QUOTE = stringPreferencesKey("quote_text")
+        private val KEY_AUTHOR = stringPreferencesKey("quote_author")
+        private val KEY_YEAR = stringPreferencesKey("quote_year")
+    }
+}
+
+class QuoteWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget = QuoteWidget()
+}

--- a/app/src/main/res/layout/widget_empty_view.xml
+++ b/app/src/main/res/layout/widget_empty_view.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/app/src/main/res/xml/quote_widget_info.xml
+++ b/app/src/main/res/xml/quote_widget_info.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="180dp"
+    android:minHeight="110dp"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/widget_empty_view"
+    android:previewImage="@mipmap/ic_launcher_new_round"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen" />


### PR DESCRIPTION
## Summary
- add a Glance app widget to display the quote of the day
- define widget metadata and placeholder layout
- register the widget receiver in the manifest

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870c035a96c832384673c12a53bc49f