### PR TITLE
Add daily quote widget support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
+        android:name=".MyApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -33,6 +34,17 @@
             android:name="androidx.work.impl.WorkManagerInitializer"
             android:authorities="${applicationId}.workmanager-init"
             tools:node="remove" />
+
+        <receiver
+            android:name="com.quvntvn.qotd_app.widget.QuoteOfTheDayReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/quote_widget_info" />
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/quvntvn/qotd_app/MyApp.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/MyApp.kt
@@ -1,0 +1,10 @@
+package com.quvntvn.qotd_app
+
+import android.app.Application
+
+/**
+ * Application class exposing a shared [QuoteRepository] instance.
+ */
+class MyApp : Application() {
+    val quoteRepository: QuoteRepository by lazy { QuoteRepository() }
+}

--- a/app/src/main/java/com/quvntvn/qotd_app/QuoteViewModel.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/QuoteViewModel.kt
@@ -67,4 +67,23 @@ class QuoteRepository {
             null
         }
     }
+
+    /**
+     * Returns the daily quote or a fallback one when the API request fails.
+     */
+    suspend fun dailyQuote(): Quote {
+        return getDailyQuote() ?: Quote(
+            citation = "",
+            auteur = "",
+            dateCreation = null
+        )
+    }
+
+    /**
+     * Returns a random quote. If the random request fails, fall back to the
+     * daily quote to avoid empty content in the widget.
+     */
+    suspend fun randomQuote(): Quote {
+        return getRandomQuote() ?: dailyQuote()
+    }
 }

--- a/app/src/main/res/layout/widget_placeholder.xml
+++ b/app/src/main/res/layout/widget_placeholder.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" >
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/loading" />
+</FrameLayout>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -21,4 +21,5 @@
     <string name="notifications_disabled">Notifications disabled</string>
     <string name="settings_title">Settings</string>
     <string name="quote_error">Unable to retrieve quote.</string>
+    <string name="loading">Loading…</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,5 @@
     <string name="notifications_disabled">Notifications désactivées</string>
     <string name="settings_title">Réglages</string>
     <string name="quote_error">Probléme de récupération de la citation.</string>
+    <string name="loading">Chargement…</string>
 </resources>

--- a/app/src/main/res/xml/quote_widget_info.xml
+++ b/app/src/main/res/xml/quote_widget_info.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-  
-</PreferenceScreen>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="150dp"
+    android:minHeight="90dp"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/widget_placeholder"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen" />


### PR DESCRIPTION
## Summary
- expose QuoteRepository from new `MyApp` application class
- extend `QuoteRepository` to provide fallbacks for widget refresh
- register widget provider and add metadata for AppWidget
- include placeholder layout and string resources used by the widget

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870c621a724832390ae65ae42bee59d