### PR TITLE
Implement widget placeholder and application class

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
+        android:name=".MyApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/quvntvn/qotd_app/MyApp.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/MyApp.kt
@@ -1,0 +1,8 @@
+package com.quvntvn.qotd_app
+
+import android.app.Application
+
+class MyApp : Application() {
+    val quoteRepository: QuoteRepository by lazy { QuoteRepository() }
+}
+

--- a/app/src/main/res/layout/widget_placeholder.xml
+++ b/app/src/main/res/layout/widget_placeholder.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center">
+
+    <TextView
+        android:id="@+id/tvPlaceholder"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/loading" />
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">Citation du jour</string>
+    <string name="loading">Chargement…</string>
     <!-- Simple English text avoids parsing issues on some build tools -->
     <string name="notification_channel_name">Citations</string>
     <string name="notification_channel_description">Notifications pour les citations quotidiennes</string>


### PR DESCRIPTION
## Summary
- register a custom `Application` class for repository access
- add a loading string
- add placeholder layout for the widget

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870cce374348323a750f5a210588867