### PR TITLE
Fix translator cleanup

### DIFF
--- a/app/src/main/java/com/quvntvn/qotd_app/MainActivity.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/MainActivity.kt
@@ -41,6 +41,8 @@ class MainActivity : AppCompatActivity() {
 
     private val viewModel: QuoteViewModel by viewModels() // Assurez-vous que QuoteViewModel existe et est configuré
 
+    private lateinit var translator: TranslationManager
+
     private val notifPermission =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
             if (!granted)
@@ -140,7 +142,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         // ---------- Observers ----------
-        val translator = TranslationManager(this)
+        translator = TranslationManager(this)
 
         viewModel.quote.observe(this) { q ->
             q ?: return@observe
@@ -199,5 +201,10 @@ class MainActivity : AppCompatActivity() {
                 notifPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
             }
         }
+    }
+
+    override fun onDestroy() {
+        translator.close()
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/com/quvntvn/qotd_app/QuoteWorker.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/QuoteWorker.kt
@@ -47,12 +47,15 @@ class QuoteWorker(
                 response.body()?.let { quote ->
                     val lang = SharedPrefManager.getLanguage(appContext)
                     val citationText = if (lang == "en") { // Vous pourriez vouloir aussi traduire si la langue est "fr" et que la citation est dans une autre langue
+                        val translator = TranslationManager(appContext)
                         try {
                             // Assurez-vous que TranslationManager gère bien les exceptions réseau etc.
-                            TranslationManager(appContext).translate(quote.citation, lang)
+                            translator.translate(quote.citation, lang)
                         } catch (e: Exception) {
                             Log.e(TAG, "Erreur de traduction: ${e.localizedMessage}", e)
                             quote.citation // Retour à la citation originale en cas d'erreur
+                        } finally {
+                            translator.close()
                         }
                     } else {
                         quote.citation

--- a/app/src/main/java/com/quvntvn/qotd_app/TranslationManager.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/TranslationManager.kt
@@ -16,6 +16,13 @@ class TranslationManager(private val context: Context) {
         Translation.getClient(options)
     }
 
+    fun close() {
+        try {
+            frToEnTranslator.close()
+        } catch (_: Exception) {
+        }
+    }
+
     suspend fun translate(text: String, target: String): String {
         if (target == "fr") return text
         val translator = when (target) {


### PR DESCRIPTION
## Summary
- close MLKit translator resources properly
- persist translator instance in `MainActivity` for reuse and close it on destroy
- ensure worker also closes translator after use

## Testing
- `./gradlew test --no-daemon` *(fails: unable to start Gradle build)*

------
https://chatgpt.com/codex/tasks/task_e_6878fb6b84e88323b49eff6d6be79d2e