### PR TITLE
Fix preference state updates in widget

### DIFF
--- a/app/src/main/java/com/quvntvn/qotd_app/QuoteOfTheDayWidget.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/QuoteOfTheDayWidget.kt
@@ -24,10 +24,11 @@ import com.quvntvn.qotd_app.MyApp
 class QuoteOfTheDayWidget : GlanceAppWidget() {
     override val stateDefinition = PreferencesGlanceStateDefinition
 
-    private val quoteTextKey = stringPreferencesKey("quote_text")
-    private val quoteAuthorKey = stringPreferencesKey("quote_author")
+    companion object {
+        val quoteTextKey = stringPreferencesKey("quote_text")
+        val quoteAuthorKey = stringPreferencesKey("quote_author")
+    }
 
-    @Composable
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val prefs = currentState<Preferences>()
 
@@ -79,7 +80,7 @@ class QuoteOfTheDayWidget : GlanceAppWidget() {
             val repo = (context.applicationContext as MyApp).quoteRepository
             val quote = repo.getRandomQuote() ?: return
 
-            updateAppWidgetState(context, PreferencesGlanceStateDefinition, glanceId) { prefs ->
+            updateAppWidgetState(context, glanceId) { prefs ->
                 prefs[quoteTextKey]   = quote.citation
                 prefs[quoteAuthorKey] = quote.auteur
             }

--- a/app/src/main/java/com/quvntvn/qotd_app/QuoteRefreshWorker.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/QuoteRefreshWorker.kt
@@ -31,7 +31,7 @@ class QuoteRefreshWorker(
         val quote = repo.getDailyQuote() ?: return Result.retry()
 
         glanceIds.forEach { id ->
-            updateAppWidgetState(ctx, PreferencesGlanceStateDefinition, id) { prefs ->
+            updateAppWidgetState(ctx, id) { prefs ->
                 prefs[quoteTextKey]   = quote.citation
                 prefs[quoteAuthorKey] = quote.auteur
             }


### PR DESCRIPTION
## Summary
- make preference keys accessible to callback
- update widget refresh logic to use `updateAppWidgetState` helper
- remove wrong `@Composable` annotation

## Testing
- `./gradlew tasks --all`
- ⚠️ `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879039e5b40832384078cbf99b2dbf9