### PR TITLE
Fix Compose widget state retrieval

### DIFF
--- a/app/src/main/java/com/quvntvn/qotd_app/QuoteOfTheDayWidget.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/QuoteOfTheDayWidget.kt
@@ -30,12 +30,11 @@ class QuoteOfTheDayWidget : GlanceAppWidget() {
     }
 
     override suspend fun provideGlance(context: Context, id: GlanceId) {
-        val prefs = currentState<Preferences>()
-
-        val quote  = prefs[quoteTextKey]    ?: context.getString(R.string.loading)
-        val author = prefs[quoteAuthorKey]  ?: ""
-
         provideContent {
+            val prefs = currentState<Preferences>()
+
+            val quote  = prefs[quoteTextKey]    ?: context.getString(R.string.loading)
+            val author = prefs[quoteAuthorKey]  ?: ""
             // UI declarative style (Compose-like)
             Box(
                 modifier = GlanceModifier


### PR DESCRIPTION
## Summary
- fix `QuoteOfTheDayWidget` to retrieve state inside `provideContent` lambda

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687908addd608323babd1ab41e6b75c9