### PR TITLE
Fix crash when scheduling alarms

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- Needed to schedule exact alarms for the daily quote notification -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <application
         android:name=".MyApp"
         android:allowBackup="true"


### PR DESCRIPTION
## Summary
- add `SCHEDULE_EXACT_ALARM` permission so daily quote alarms can be scheduled

## Testing
- `./gradlew test --continue` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687935a0e818832394fb4a5a8be7b51f