### PR TITLE
Update widget refresh timing

### DIFF
--- a/app/src/main/java/com/quvntvn/qotd_app/MyApp.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/MyApp.kt
@@ -1,8 +1,14 @@
 package com.quvntvn.qotd_app
 
 import android.app.Application
+import com.quvntvn.qotd_app.QuoteRefreshWorker
 
 class MyApp : Application() {
     val quoteRepository: QuoteRepository by lazy { QuoteRepository() }
+
+    override fun onCreate() {
+        super.onCreate()
+        QuoteRefreshWorker.schedule(applicationContext)
+    }
 }
 

--- a/app/src/main/java/com/quvntvn/qotd_app/QuoteRefreshWorker.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/QuoteRefreshWorker.kt
@@ -54,7 +54,7 @@ class QuoteRefreshWorker(
             val now = Calendar.getInstance()
             val tomorrow = Calendar.getInstance().apply {
                 set(Calendar.HOUR_OF_DAY, 0)
-                set(Calendar.MINUTE, 0)
+                set(Calendar.MINUTE, 1)
                 set(Calendar.SECOND, 0)
                 set(Calendar.MILLISECOND, 0)
                 add(Calendar.DAY_OF_YEAR, 1)


### PR DESCRIPTION
## Summary
- schedule daily widget refresh from `MyApp`
- update worker delay to trigger at 00:01
- remove refresh button from widget
- schedule updates when widget is first added

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a53fba4e08323b806c1111fa896c1