### PR TITLE
Fix widget initial quote loading

### DIFF
--- a/app/src/main/java/com/quvntvn/qotd_app/MyApp.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/MyApp.kt
@@ -9,6 +9,7 @@ class MyApp : Application() {
     override fun onCreate() {
         super.onCreate()
         QuoteRefreshWorker.schedule(applicationContext)
+        QuoteRefreshWorker.refreshOnce(applicationContext)
     }
 }
 

--- a/app/src/main/java/com/quvntvn/qotd_app/QuoteOfTheDayWidget.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/QuoteOfTheDayWidget.kt
@@ -71,6 +71,9 @@ class QuoteOfTheDayReceiver : GlanceAppWidgetReceiver() {
 
     override fun onEnabled(context: Context?) {
         super.onEnabled(context)
-        context?.let { QuoteRefreshWorker.schedule(it.applicationContext) }
+        context?.let {
+            QuoteRefreshWorker.schedule(it.applicationContext)
+            QuoteRefreshWorker.refreshOnce(it.applicationContext)
+        }
     }
 }

--- a/app/src/main/java/com/quvntvn/qotd_app/QuoteRefreshWorker.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/QuoteRefreshWorker.kt
@@ -8,9 +8,11 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import androidx.work.OneTimeWorkRequestBuilder
 import com.quvntvn.qotd_app.widget.QuoteOfTheDayWidget
 import com.quvntvn.qotd_app.MyApp
 import java.util.concurrent.TimeUnit
@@ -47,6 +49,16 @@ class QuoteRefreshWorker(
                 .build()
             WorkManager.getInstance(context).enqueueUniquePeriodicWork(
                 "widget_refresh", ExistingPeriodicWorkPolicy.UPDATE, request
+            )
+        }
+
+        fun refreshOnce(context: Context) {
+            val request = OneTimeWorkRequestBuilder<QuoteRefreshWorker>()
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                "widget_refresh_once",
+                ExistingWorkPolicy.REPLACE,
+                request
             )
         }
 


### PR DESCRIPTION
## Summary
- immediately refresh the daily quote when placing the widget
- allow the app to load today's quote on startup

## Testing
- `./gradlew assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a5ea380248323a8d5eb57805ec7e3