### PR TITLE
Fix WorkManager initialization

### DIFF
--- a/app/src/main/java/com/quvntvn/qotd_app/MyApp.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/MyApp.kt
@@ -1,15 +1,30 @@
 package com.quvntvn.qotd_app
 
 import android.app.Application
-import com.quvntvn.qotd_app.QuoteRefreshWorker
+import android.util.Log
+import androidx.work.Configuration
+import androidx.work.WorkManager
 
-class MyApp : Application() {
+/**
+ * Application class responsible for WorkManager initialization.
+ */
+class MyApp : Application(), Configuration.Provider {
+
     val quoteRepository: QuoteRepository by lazy { QuoteRepository() }
+
+    override fun getWorkManagerConfiguration(): Configuration =
+        Configuration.Builder()
+            .setMinimumLoggingLevel(Log.INFO)
+            .build()
 
     override fun onCreate() {
         super.onCreate()
+        // Manual initialization because WorkManagerInitializer is removed
+        WorkManager.initialize(this, getWorkManagerConfiguration())
+
         QuoteRefreshWorker.schedule(applicationContext)
         QuoteRefreshWorker.refreshOnce(applicationContext)
     }
 }
+
 


### PR DESCRIPTION
## Summary
- manually initialize WorkManager since the default provider is removed

## Testing
- `./gradlew test --console=plain --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b714e8da88323ac64fd7cf4d3c9d4