### PR TITLE
Fix WorkManager initialization

### DIFF
--- a/app/src/main/java/com/quvntvn/qotd_app/MyApp.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/MyApp.kt
@@ -12,15 +12,15 @@ class MyApp : Application(), Configuration.Provider {
 
     val quoteRepository: QuoteRepository by lazy { QuoteRepository() }
 
-    override fun getWorkManagerConfiguration(): Configuration =
-        Configuration.Builder()
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
             .setMinimumLoggingLevel(Log.INFO)
             .build()
 
     override fun onCreate() {
         super.onCreate()
         // Manual initialization because WorkManagerInitializer is removed
-        WorkManager.initialize(this, getWorkManagerConfiguration())
+        WorkManager.initialize(this, workManagerConfiguration)
 
         QuoteRefreshWorker.schedule(applicationContext)
         QuoteRefreshWorker.refreshOnce(applicationContext)


### PR DESCRIPTION
## Summary
- implement WorkManager configuration using the new `workManagerConfiguration` property
- update initialization call to use the property

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c7750cac08323838cd8578401782d