### PR TITLE
Fix WorkManager re-initialization

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,10 +32,15 @@
             android:name=".SettingsActivity"
             android:exported="false"
             android:label="@string/app_name" />
+        <!-- Disable automatic WorkManager initialization -->
         <provider
-            android:name="androidx.work.impl.WorkManagerInitializer"
-            android:authorities="${applicationId}.workmanager-init"
-            tools:node="remove" />
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                tools:node="remove" />
+        </provider>
         <receiver
             android:name=".widget.QuoteOfTheDayReceiver"
             android:exported="false">


### PR DESCRIPTION
## Summary
- disable WorkManager auto initializer correctly

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ca02321488323833a0cf6e06dfcc9