### PR TITLE
Handle translation failures gracefully

### DIFF
--- a/app/src/main/java/com/quvntvn/qotd_app/MainActivity.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/MainActivity.kt
@@ -13,6 +13,7 @@ import android.widget.ImageButton
 import android.widget.ProgressBar
 import android.widget.TextView
 import android.widget.Toast
+import android.util.Log
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -149,7 +150,13 @@ class MainActivity : AppCompatActivity() {
             q ?: return@observe
             lifecycleScope.launch {
                 val lang = SharedPrefManager.getLanguage(this@MainActivity)
-                tvQuote.text  = "« ${translator.translate(q.citation, lang)} »"
+                val translated = try {
+                    translator.translate(q.citation, lang)
+                } catch (e: Exception) {
+                    Log.e("MainActivity", "Translation failed", e)
+                    q.citation
+                }
+                tvQuote.text = "« $translated »"
                 tvAuthor.text = q.auteur
 
                 val dateText = q.dateCreation?.take(4)


### PR DESCRIPTION
## Summary
- log translation errors and fallback to original citation

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cf608cc4c8323b6ad53f08e176229