### PR TITLE
Fix QuoteRefreshWorker crash with safe app context cast

### DIFF
--- a/app/src/main/java/com/quvntvn/qotd_app/QuoteRefreshWorker.kt
+++ b/app/src/main/java/com/quvntvn/qotd_app/QuoteRefreshWorker.kt
@@ -29,7 +29,9 @@ class QuoteRefreshWorker(
     override suspend fun doWork(): Result {
         val ctx = applicationContext
         val glanceIds = GlanceAppWidgetManager(ctx).getGlanceIds(QuoteOfTheDayWidget::class.java)
-        val repo = (ctx as MyApp).quoteRepository
+
+        val repo = (ctx as? MyApp)?.quoteRepository
+            ?: return Result.failure()
         val quote = repo.getDailyQuote() ?: return Result.retry()
 
         glanceIds.forEach { id ->


### PR DESCRIPTION
## Summary
- prevent potential crash in `QuoteRefreshWorker` by safely casting the application context to `MyApp`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d1f4296788323ae3716e7af0f84c4