### PR TITLE
Fix(MainActivity): Résolution du crash lors de la rotation en mode pa…

### DIFF
--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -7,17 +7,24 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <ImageView
-        android:id="@+id/backgroundImage"
+    <eightbitlab.com.blurview.BlurTarget
+        android:id="@+id/blur_target"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:scaleType="centerCrop"
-        android:src="@drawable/fond"
-        android:contentDescription="@null"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <ImageView
+            android:id="@+id/backgroundImage"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="centerCrop"
+            android:src="@drawable/fond"
+            android:contentDescription="@null" />
+
+    </eightbitlab.com.blurview.BlurTarget>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/content_container"


### PR DESCRIPTION
…ysage

Le problème était dû à l'absence de la vue `BlurTarget` dans le fichier de mise en page pour le mode paysage (`layout-land/activity_main.xml`). Lorsque l'application passait en mode paysage, le code ne trouvait pas la vue cible (`blur_target`), ce qui entraînait une `NullPointerException` dans la bibliothèque `BlurView`.

Cette correction enveloppe l'`ImageView` de fond dans une `BlurTarget` au sein de la mise en page paysage, assurant ainsi sa présence quelle que soit l'orientation de l'appareil et résolvant le crash.