### PR TITLE
Fix(settings): Prevent crash on screen rotation

### DIFF
--- a/app/src/main/res/layout-land/activity_settings.xml
+++ b/app/src/main/res/layout-land/activity_settings.xml
@@ -7,17 +7,24 @@
     android:layout_height="match_parent"
     tools:context=".SettingsActivity">
 
-    <ImageView
-        android:id="@+id/settingsBackgroundImage"
+    <eightbitlab.com.blurview.BlurTarget
+        android:id="@+id/settings_blur_target"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:scaleType="centerCrop"
-        android:src="@drawable/fond"
-        android:contentDescription="@null"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <ImageView
+            android:id="@+id/settingsBackgroundImage"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="centerCrop"
+            android:src="@drawable/fond"
+            android:contentDescription="@null" />
+
+    </eightbitlab.com.blurview.BlurTarget>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/settings_content_container_land"


### PR DESCRIPTION
The settings activity was crashing when the screen was rotated to landscape mode. This was caused by a NullPointerException in the `setupBlurViews` method, as the `settings_blur_target` view was missing from the landscape layout file (`layout-land/activity_settings.xml`).

This commit adds the missing `BlurTarget` view to the landscape layout, ensuring it matches the portrait layout. This prevents the crash and allows the activity to be recreated successfully in landscape mode.

Additionally, the notification setup was reviewed as requested. The existing implementation in `NotificationHelper.kt` and `QuoteAlarmReceiver.kt` was found to be robust and correct, so no changes were made to the notification logic.