### PR TITLE
fix: Rétrograde les dépendances pour corriger le crash au démarrage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace = "com.quvntvn.qotd_app"
-    compileSdk = 35
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.quvntvn.qotd_app"
         minSdk = 28
-        targetSdk = 35
+        targetSdk = 34
         versionCode = 11
         versionName = "1.1.9"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -42,9 +42,9 @@ android {
 // LE BLOC REPOSITORIES A ÉTÉ SUPPRIMÉ D'ICI
 
 dependencies {
-    implementation("com.github.Dimezis:BlurView:version-3.1.0")
+    implementation("com.github.Dimezis:BlurView:version-2.0.3")
 
-    implementation(platform("androidx.compose:compose-bom:2025.06.00"))
+    implementation(platform("androidx.compose:compose-bom:2024.02.02"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
@@ -70,7 +70,7 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
-    androidTestImplementation(platform("androidx.compose:compose-bom:2025.06.00"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2024.02.02"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")


### PR DESCRIPTION
L'application crashait au lancement sur des appareils récents comme le Samsung Galaxy S24. L'enquête a révélé l'utilisation de dépendances de pré-version, notamment :
- SDK Android 35 (pré-version)
- Compose BOM 2025.06.00 (pré-version)
- BlurView version-3.1.0 (version de développement)

Ce commit rétrograde ces dépendances vers les dernières versions stables connues pour assurer la compatibilité et la stabilité sur les appareils de production.

Changements :
- `compileSdk` et `targetSdk` sont passés de 35 à 34.
- La version du Compose BOM est passée à `2024.02.02`.
- La version de `BlurView` est passée à `version-2.0.3`.